### PR TITLE
Fix to make getPlaylist function apply cachebusting for Phone/Tablet browsers

### DIFF
--- a/js/player_lib.js
+++ b/js/player_lib.js
@@ -122,41 +122,49 @@ function renderUI(data) {
 }
 
 function getPlaylist(json){
-    $.getJSON('db/?cmd=playlist', function(data) {
-        var i = 0;
-        var content = '';
-        var output = '';
-        for (i = 0; i < data.length; i++){
-            if (json['state'] != 'stop' && i == parseInt(json['song'])) {
-                content = '<li id="pl-' + (i + 1) + '" class="active clearfix">';
-            } else {
-                content = '<li id="pl-' + (i + 1) + '" class="clearfix">';
+    $.ajax({
+        type: 'GET',
+        dataType: 'json',
+        url: 'db/?cmd=playlist',
+        cache: false,
+        async: true,
+
+        success: function (data) {
+            var i = 0;
+            var content = '';
+            var output = '';
+            for (i = 0; i < data.length; i++) {
+                if (json['state'] != 'stop' && i == parseInt(json['song'])) {
+                    content = '<li id="pl-' + (i + 1) + '" class="active clearfix">';
+                } else {
+                    content = '<li id="pl-' + (i + 1) + '" class="clearfix">';
+                }
+                content += '<div class="pl-action"><a class="btn" href="#notarget" title="Remove song from playlist"><i class="icon-remove-sign"></i></a></div>';
+                if (typeof data[i].Title != 'undefined') {
+                    content += '<div class="pl-entry">';
+                    content += data[i].Title + ' <em class="songtime">' + timeConvert(data[i].Time) + '</em>';
+                    content += ' <span>';
+                    content += data[i].Artist;
+                    content += ' - ';
+                    content += data[i].Album;
+                    content += '</span></div></li>';
+                    output = output + content;
+                } else {
+                    songpath = parsePath(data[i].file);
+                    content += '<div class="pl-entry">';
+                    content += data[i].file.replace(songpath + '/', '') + ' <em class="songtime">' + timeConvert(data[i].Time) + '</em>';
+                    content += ' <span>';
+                    content += ' path \: ';
+                    content += songpath;
+                    content += '</span></div></li>';
+                    output = output + content;
+                }
             }
-			content += '<div class="pl-action"><a class="btn" href="#notarget" title="Remove song from playlist"><i class="icon-remove-sign"></i></a></div>';
-            if (typeof data[i].Title != 'undefined') {
-                content += '<div class="pl-entry">';
-                content += data[i].Title + ' <em class="songtime">' + timeConvert(data[i].Time) + '</em>';
-                content += ' <span>';
-                content +=  data[i].Artist;
-                content += ' - ';
-                content +=  data[i].Album;
-                content += '</span></div></li>';
-                output = output + content;
-            } else {
-                songpath = parsePath(data[i].file);
-                content += '<div class="pl-entry">';
-                content += data[i].file.replace(songpath + '/', '') + ' <em class="songtime">' + timeConvert(data[i].Time) + '</em>';
-                content += ' <span>';
-                content += ' path \: ';
-                content += songpath;
-                content += '</span></div></li>';
-                output = output + content;
+            $('ul.playlist').html(output);
+            var current = parseInt(json['song']);
+            if (current != json && GUI.halt != 1) {
+                customScroll('pl', current, 200); // active current song
             }
-        }
-        $('ul.playlist').html(output);
-        var current = parseInt(json['song']);
-        if (current != json && GUI.halt != 1) {
-            customScroll('pl', current, 200); // active current song
         }
     });
 }


### PR DESCRIPTION
I would like to submit this bug fix which adjusts the getPlaylist function in player_lib.js to use the cache: false flag on its ajax request. This fixes a bug on my local setup where if you view the playlist tab using a phone or tablet you would always see old data.

I tested it on my Lumia 2520 using Internet Explorer, and also on my Lumia 920 phone also using IE. I also tested using Chrome on my desktop and all three cases work.