### PR TITLE
Fixing init-script for shairport

### DIFF
--- a/_OS_SETTINGS/etc/init.d/shairport
+++ b/_OS_SETTINGS/etc/init.d/shairport
@@ -14,7 +14,7 @@ NAME="Volumio"
  
 case "$1" in
   start)
-    /usr/local/bin/shairport -d -a "$NAME" -w -B "mpc stop"
+    /usr/local/bin/shairport -d -a "$NAME" -B "mpc stop"
     ;;
   stop)
     killall shairport


### PR DESCRIPTION
fixes #19 

I removed the now unsupported parameter "-w". Init-script works again.

Best Regards,
Robin
