### PR TITLE
added media qy for small devices (320px)

### DIFF
--- a/css/panels.css
+++ b/css/panels.css
@@ -882,6 +882,14 @@ body { background: #cf0; } */
 		display: none;
 	}
 }
+@media (max-width: 320px) {
+    #menu-bottom li a {
+		font-size: 30px;
+	}
+    #menu-bottom .sx {
+        margin:0 auto;
+    }
+}
 <<<<<<< HEAD
 
 #lib-load {


### PR DESCRIPTION
added media query to fix the bottom menu on small devices
before:
![screenshot-area-2014-07-15-220306](https://cloud.githubusercontent.com/assets/291082/3593399/f8f476e8-0c84-11e4-9654-73c925e42b1f.png)

after:
![screenshot-area-2014-07-15-220207](https://cloud.githubusercontent.com/assets/291082/3593397/db5514c6-0c84-11e4-9396-77c07a426fab.png)
