### PR TITLE
deny web access to _OS_SETTINGS

### DIFF
--- a/_OS_SETTINGS/etc/nginx/nginx.conf
+++ b/_OS_SETTINGS/etc/nginx/nginx.conf
@@ -44,6 +44,10 @@ http {
 	location /command {
 	proxy_pass        http://localhost:82/;
 	}
+	
+	location ^~ /_OS_SETTINGS {
+	    deny all;
+	}
 
         # redirect server error pages to the static page /50x.html
         #


### PR DESCRIPTION
I don't really see a reason why this should be accessible via web...
