### PR TITLE
Spotify search and add to queue

### DIFF
--- a/db/index.php
+++ b/db/index.php
@@ -118,8 +118,18 @@ if (isset($_GET['cmd']) && $_GET['cmd'] != '') {
 				
 				case 'search':
 					if (isset($_POST['query']) && $_POST['query'] != '' && isset($_GET['querytype']) && $_GET['querytype'] != '') {
-						echo json_encode(searchDB($mpd,$_GET['querytype'],$_POST['query']));
+						$arraySearchResults = searchDB($mpd,$_GET['querytype'],$_POST['query']);
+
+						if ($spop) {
+							$arraySpopSearchResults = querySpopDB($spop, 'file', $_POST['query']);
+							$arraySearchResults = array_merge($arraySearchResults, $arraySpopSearchResults);
+
+						}
+
+						echo json_encode($arraySearchResults);
+
 					}
+
 					break;
 
 				case 'loadlib':
@@ -145,11 +155,24 @@ if (isset($_GET['cmd']) && $_GET['cmd'] != '') {
 					}
 					break;
 
+				case 'spop-addtrackuri':
+					if (isset($_POST['path']) && $_POST['path'] != '') {
+						echo sendSpopCommand($spop, "uadd " . $_POST['path']);
+					}
+					break;
+
 				case 'spop-playplaylistindex':
 					if (isset($_POST['path']) && $_POST['path'] != '') {
 						$sSpopPlaylistIndex = end(explode("@", $_POST['path']));
 						sendMpdCommand($mpd,'stop');
 						echo sendSpopCommand($spop, "play " . $sSpopPlaylistIndex);
+					}
+					break;
+
+				case 'spop-addplaylistindex':
+					if (isset($_POST['path']) && $_POST['path'] != '') {
+						$sSpopPlaylistIndex = end(explode("@", $_POST['path']));
+						echo sendSpopCommand($spop, "add " . $sSpopPlaylistIndex);
 					}
 					break;
 

--- a/inc/player_lib.php
+++ b/inc/player_lib.php
@@ -302,8 +302,11 @@ echo $template;
 // Perform Spotify database query/search
 function querySpopDB($sock, $queryType, $queryString) {
 
-	if(strcmp($queryType, "filepath") == 0) {
+	if (strcmp($queryType, "filepath") == 0) {
 		return _getSpopListing($sock, $queryString);
+
+	} else if (strcmp($queryType, "file") == 0) {
+		return _searchSpopTracks($sock, $queryString);
 
 	}
 
@@ -395,6 +398,29 @@ function sysCmd($syscmd) {
 function _parseSpopResponse($resp) {
 	return json_decode($resp, true);
 
+}
+
+// Perform a Spotify search
+function _searchSpopTracks($sock, $queryString) {
+	$arrayReturn = array();
+	$arrayResponse = sendSpopCommand($sock,"search \"" . $queryString . "\"");
+
+	$i = 0;
+	$nItems = sizeof($arrayResponse["tracks"]);
+	while ($i < $nItems) {
+		$arrayCurrentEntry = array();
+		$arrayCurrentEntry["Type"] = "SpopTrack";
+		$arrayCurrentEntry["SpopTrackUri"] = (string)$arrayResponse["tracks"][$i]["uri"];
+		$arrayCurrentEntry["Title"] = $arrayResponse["tracks"][$i]["title"];
+		$arrayCurrentEntry["Artist"] = $arrayResponse["tracks"][$i]["artist"];
+		$arrayCurrentEntry["Album"] = $arrayResponse["tracks"][$i]["album"];
+
+		array_push($arrayReturn, $arrayCurrentEntry);
+
+		$i++;
+	}
+
+	return $arrayReturn;
 }
 
 // Make an array describing the requested level of the Spop database

--- a/js/volumio.playback.js
+++ b/js/volumio.playback.js
@@ -407,8 +407,16 @@ jQuery(document).ready(function($){ 'use strict';
 			$.post('db/?cmd=spop-playtrackuri', { 'path': path }, function(data) {}, 'json');
 
         }
+        if ($(this).data('cmd') == 'spop-addtrackuri') {
+			$.post('db/?cmd=spop-addtrackuri', { 'path': path }, function(data) {}, 'json');
+
+        }
         if ($(this).data('cmd') == 'spop-playplaylistindex') {
 			$.post('db/?cmd=spop-playplaylistindex', { 'path': path }, function(data) {}, 'json');
+
+        }
+        if ($(this).data('cmd') == 'spop-addplaylistindex') {
+			$.post('db/?cmd=spop-addplaylistindex', { 'path': path }, function(data) {}, 'json');
 
         }
         if ($(this).data('cmd') == 'spop-stop') {

--- a/templates/indextpl.html
+++ b/templates/indextpl.html
@@ -169,12 +169,14 @@
 	</div>
 	<div id="context-menu-spotifytrack" class="context-menu">
 		<ul class="dropdown-menu" role="menu">
-			<li><a href="#notarget" data-cmd="spop-playtrackuri"><i class="fa fa-play sx"></i>Spotify Play</a></li>
+			<li><a href="#notarget" data-cmd="spop-playtrackuri"><i class="fa fa-share sx"></i>Spotify Add, replace and play</a></li>
+			<li><a href="#notarget" data-cmd="spop-addtrackuri"><i class="fa fa-plus sx"></i>Spotify Add</a></li>
 		</ul>
 	</div>
 	<div id="context-menu-spotifyplaylist" class="context-menu">
 		<ul class="dropdown-menu" role="menu">
-			<li><a href="#notarget" data-cmd="spop-playplaylistindex"><i class="fa fa-play sx"></i>Spotify Play</a></li>
+			<li><a href="#notarget" data-cmd="spop-playplaylistindex"><i class="fa fa-share sx"></i>Spotify Add, replace and play</a></li>
+			<li><a href="#notarget" data-cmd="spop-addplaylistindex"><i class="fa fa-plus sx"></i>Spotify Add</a></li>
 		</ul>
 	</div>
 </div>


### PR DESCRIPTION
db/index.php
- Add Spotify results to 'search' query output
- Make callback listeners for Spop add-to-queue commands

inc/player_lib.php
- Add Spotify search function which returns array of tracks matching query

js/volumio.playback.js
- Add callbacks for Spop add-to-queue commands

templates/indextpl.html
- Add context menu items for Spop add-to-queue
