### PR TITLE
Add SSHFS support

### DIFF
--- a/inc/player_lib.php
+++ b/inc/player_lib.php
@@ -1348,14 +1348,22 @@ function wrk_sourcemount($db,$action,$id) {
 			$mp = cfgdb_read('cfg_source',$dbh,'',$id);
 			sysCmd("mkdir \"/mnt/NAS/".$mp[0]['name']."\"");
 			if ($mp[0]['type'] == 'cifs') {
-			// smb/cifs mount
-			if (empty($mp[0]['username'])) {
-			$mp[0]['username'] = 'guest';
-			}
-			$mountstr = "mount -t cifs \"//".$mp[0]['address']."/".$mp[0]['remotedir']."\" -o username=".$mp[0]['username'].",password=".$mp[0]['password'].",rsize=".$mp[0]['rsize'].",wsize=".$mp[0]['wsize'].",iocharset=".$mp[0]['charset'].",".$mp[0]['options']." \"/mnt/NAS/".$mp[0]['name']."\"";
+				// smb/cifs mount
+				if (empty($mp[0]['username'])) {
+					$mp[0]['username'] = 'guest';
+				}
+				$mountstr = "mount -t cifs \"//".$mp[0]['address']."/".$mp[0]['remotedir']."\" -o username=".$mp[0]['username'].",password=".$mp[0]['password'].",rsize=".$mp[0]['rsize'].",wsize=".$mp[0]['wsize'].",iocharset=".$mp[0]['charset'].",".$mp[0]['options']." \"/mnt/NAS/".$mp[0]['name']."\"";
+			} elseif ($mp[0]['type'] == 'sshfs') {
+				// sshfs mount
+				// TODO document (ignores password, passwordless key required)
+				// TODO document remotedir probably needs to be absolute
+				// TODO support options
+				$options = " -ouid=`id -u` -ogid=`id -g` "; // so the mount shows up as a local rather than remote user
+				$options .= " -oallow_other "; // so the "pi" user can access files
+				$mountstr = "sshfs {$mp[0]['username']}@{$mp[0]['address']}:{$mp[0]['remotedir']} $options \"/mnt/NAS/{$mp[0]['name']}\"";
 			} else {
-			// nfs mount
-			$mountstr = "mount -t nfs -o ".$mp[0]['options']." \"".$mp[0]['address'].":/".$mp[0]['remotedir']."\" \"/mnt/NAS/".$mp[0]['name']."\"";
+				// nfs mount
+				$mountstr = "mount -t nfs -o ".$mp[0]['options']." \"".$mp[0]['address'].":/".$mp[0]['remotedir']."\" \"/mnt/NAS/".$mp[0]['name']."\"";
 			}
 			// debug
 			error_log(">>>>> mount string >>>>> ".$mountstr,0);
@@ -1398,10 +1406,16 @@ unset($queueargs['mount']['action']);
 		case 'reset': 
 		$dbh = cfgdb_connect($db);
 		$source = cfgdb_read('cfg_source',$dbh);
-			foreach ($source as $mp) {
-			sysCmd("umount -f \"/mnt/NAS/".$mp['name']."\"");
-			sysCmd("rmdir \"/mnt/NAS/".$mp['name']."\"");
+		foreach ($source as $mp) {
+			if ($mp['name'] == 'sshfs') {
+				// unmount FUSE file systems properly
+				sysCmd("fusermount -u \"/mnt/NAS/{$mp['name']}\"");
+			} else {
+				// normal file systems
+				sysCmd("umount -f \"/mnt/NAS/".$mp['name']."\"");
 			}
+			sysCmd("rmdir \"/mnt/NAS/".$mp['name']."\"");
+		}
 		if (cfgdb_delete('cfg_source',$dbh)) {
 		$return = 1;
 		} else {

--- a/sources.php
+++ b/sources.php
@@ -190,8 +190,9 @@ if (isset($_GET['p']) && !empty($_GET['p'])) {
 			$_rsize = $mount['rsize'];
 			$_wsize = $mount['wsize'];
 			// mount type select
-			$_source_select['type'] .= "<option value=\"cifs\" ".(($mount['type'] == 'cifs') ? "selected" : "")." >SMB/CIFS</option>\n";	
-			$_source_select['type'] .= "<option value=\"nfs\" ".(($mount['type'] == 'nfs') ? "selected" : "")." >NFS</option>\n";	
+			$_source_select['type'] .= "<option value=\"cifs\" " .(($mount['type'] == 'cifs')  ? "selected" : "")." >SMB/CIFS</option>\n";	
+			$_source_select['type'] .= "<option value=\"sshfs\" ".(($mount['type'] == 'sshfs') ? "selected" : "")." >SSHFS</option>\n";	
+			$_source_select['type'] .= "<option value=\"nfs\" "  .(($mount['type'] == 'nfs')   ? "selected" : "")." >NFS</option>\n";	
 			$_charset = $mount['charset'];
 			$_options = $mount['options'];
 			$_error = $mount['error'];
@@ -208,6 +209,7 @@ if (isset($_GET['p']) && !empty($_GET['p'])) {
 	$_hideerror = 'hide';
 	$_action = 'add';
 	$_source_select['type'] .= "<option value=\"cifs\">SMB/CIFS</option>\n";	
+	$_source_select['type'] .= "<option value=\"sshfs\">SSHFS</option>\n";	
 	$_source_select['type'] .= "<option value=\"nfs\">NFS</option>\n";	
 	}
 	$tpl = 'source.html';

--- a/templates/sources.html
+++ b/templates/sources.html
@@ -6,7 +6,7 @@
 	<div class="tile txtsx">
 		<p>Volumio creates and updates its music database via the following source directories:</p>
 		<ul>
-			<li><strong>NAS</strong><br><span class="help-block">This section contains all your connected network shares. (SAMBA/NFS etc.)</span></li>
+			<li><strong>NAS</strong><br><span class="help-block">This section contains all your connected network shares. (Samba/SSHFS/NFS etc.)</span></li>
 			<li><strong>USB</strong><br><span class="help-block">Locally connected external USB drives. (FAT32 or NTFS)</span></li>
 			<li><strong>RAM</strong><br><span class="help-block">The content of the RAMdisk, upload your files here and enjoy RamPlay Heaven.</span></li>
 		</ul>


### PR DESCRIPTION
I have started the process of implementing SSHFS. I am doing this against v1.5 (because that's the release I started with). The following has been done:

  - [x] WebUI support for adding/removing SSHFS mounts
  - [x] Testing against v1.5; this works for me on my RaspPI using SSH keys after doing lots of manual steps

At least the following needs to be done before this can be merged:

  - [ ] Update rootfs (see below for info on changes)
  - [ ] Support a password (i.e. support not using SSH keys)
      * should not be too hard, just haven't looked at it yet
  - [ ] Support options (e.g. arcfour cipher, others)
  - [ ] Any other updates in the documentation/webui
  - [ ] Testing

Rootfs changes
--------------

To get this working, I did the following starting with a fresh install of v1.5
for the Raspberry PI:

  * `apt-get update` (probably overkill...)
  * `apt-get install sshfs fuse libfuse2` (installs `sshfs` and `libfuse2`, and upgrades `fuse`)
    ```
root@volumio:/DEVEL/mywebui# dpkg -l sshfs libfuse2 fuse | tail -n3
ii  fuse                             2.9.3-15                           armhf        Filesystem in Userspace
ii  libfuse2:armhf                   2.9.3-15                           armhf        Filesystem in Userspace (library)
ii  sshfs                            2.5-1                              armhf        filesystem client based on SSH File Transfer Protocol
```

  * added `pi` to the `fuse` group
  * uncommented `user_allow_other` in `/etc/fuse.conf`
  * used `ssh-keygen` as root to generate /root/.ssh/id_rsa.pub
  * added this public key to the `~/.ssh/authorized_keys` file on my server
