### PR TITLE
Return correct application/json content-type and get rid of evals in volumio.api.js

### DIFF
--- a/_player_engine.php
+++ b/_player_engine.php
@@ -120,6 +120,7 @@ if (!$mpd) {
 		}
 
 		// JSON response for GUI
+		header('Content-Type: application/json');
 		echo json_encode($status);
 		
 	closeMpdSocket($mpd);

--- a/_player_engine_spop.php
+++ b/_player_engine_spop.php
@@ -18,6 +18,7 @@ if (!$spop) {
 		} 
 
 		// Return data in json format to ajax requester and close socket
+		header('Content-Type: application/json');
 		echo json_encode($status);
 		closeSpopSocket($spop);
 

--- a/command/index.php
+++ b/command/index.php
@@ -31,11 +31,12 @@
 include('../inc/connection.php');
 error_reporting(ERRORLEVEL);
 
+header('Content-Type: application/json');
+
 if (isset($_GET['cmd']) && $_GET['cmd'] != '') {
 
         if ( !$mpd ) {
-        echo 'Error Connecting to MPD daemon ';
-		
+			echo json_encode(['error' => 'Error Connecting to MPD daemon']);
 		} else {
 			$sRawCommand = $_GET['cmd'];
 			$sSpopCommand = NULL;
@@ -87,9 +88,12 @@ if (isset($_GET['cmd']) && $_GET['cmd'] != '') {
         }
 
 } else {
-	echo 'MPD COMMAND INTERFACE<br>';
-	echo 'INTERNAL USE ONLY<br>';
-	echo 'hosted on raspyfi.local:82';
+	echo json_encode(
+		[
+		'service'       => 'MPD COMMAND INTERFACE',
+		'disclaimer'    => 'INTERNAL USE ONLY!',
+		'hosted_on' 	=> gethostname() . ":" . $_SERVER['SERVER_PORT']
+		]);
 
 }
 

--- a/db/index.php
+++ b/db/index.php
@@ -31,11 +31,12 @@
 include('../inc/connection.php');
 error_reporting(ERRORLEVEL);
 
+header('Content-Type: application/json');
+
 if (isset($_GET['cmd']) && $_GET['cmd'] != '') {
 
-        if ( !$mpd ) {
-        echo 'Error Connecting to MPD daemon ';
-		
+		if ( !$mpd ) {
+			echo json_encode(['error' => 'Error Connecting to MPD daemon']);	
 		}  else {
 				switch ($_GET['cmd']) {
 				
@@ -181,9 +182,12 @@ if (isset($_GET['cmd']) && $_GET['cmd'] != '') {
 		}
 
 } else {
-	echo 'MPD DB INTERFACE<br>';
-	echo 'INTERNAL USE ONLY<br>';
-	echo 'hosted on raspyfi.local:81';
+	echo json_encode(
+		[
+		'service'       => 'MPD DB INTERFACE',
+		'disclaimer'    => 'INTERNAL USE ONLY!',
+		'hosted_on' 	=> gethostname() . ":" . $_SERVER['SERVER_PORT']
+		]);
 
 }
 

--- a/js/volumio.api.js
+++ b/js/volumio.api.js
@@ -79,7 +79,7 @@ function backendRequest() {
         async : true,
         cache : false,
         success : function(data) {
-			GUI.MpdState = eval('(' + data + ')');
+			GUI.MpdState = data;
             renderUI();
             backendRequest();
         },
@@ -103,7 +103,7 @@ function backendRequestSpop() {
         cache : false,
         success : function(data) {
 			if (data != '') {
-				GUI.SpopState = eval('(' + data + ')');
+				GUI.SpopState = data;
 				renderUI();
 	            backendRequestSpop();
 			} else {

--- a/js/volumio.playback.js
+++ b/js/volumio.playback.js
@@ -182,7 +182,7 @@ jQuery(document).ready(function($){ 'use strict';
 						cache : false,
 						success : function(data) {
 							if (data != '') {
-								GUI.SpopState = eval('(' + data + ')');
+								GUI.SpopState = data;
 								renderUI();
 							}
 						}


### PR DESCRIPTION
I noticed that _player_engine.php and _player_engine_spop.php do not return the correct application/json content-type. Besides being bad practice, this also made it necessary to eval() the JSON response in volumio.api.js and volumio.playback.js. I fixed the content-type and got rid of the now unnecessary eval()s. Hopefully, this doesn't cause any side-effects, but I haven't tested the Spotify integration because I'm lacking a Spotify account.