### PR TITLE
Do not pass spotify password in all http requests to settings.php

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -117,7 +117,7 @@ $_system_select[spotify0]
 			<div class="control-group">
 				<label class="control-label" for="spotpassword">Spotify Password</label>
 				<div class="controls">
-					<input class="input-large" class="input-block-level" type="password" id="spotpassword" name="spotpassword" value="$_spotpassword" data-trigger="change" >
+					<input class="input-large" class="input-block-level" type="password" id="spotpassword" name="spotpassword" value="" data-trigger="change" >
 				</div>
 			</div>
 				


### PR DESCRIPTION
This is a security issue, anyone sniffing traffic, or accessing the unprotected settings page of a volumio web UI can see the pasword to the spotify account.

The password should also not be stored in plain text, but that is less concerning than exposing it over an unauthenticated HTTP request.