### PR TITLE
Fix hang on backendRequest error

### DIFF
--- a/js/volumio.api.js
+++ b/js/volumio.api.js
@@ -72,17 +72,18 @@ function sendPLCmd(inputcmd) {
     });
 }
 
-function backendRequest() {
+function backendRequest(send_state) {
+    url = send_state ? ('_player_engine.php?state=' + GUI.MpdState['state']) : '_player_engine.php'
     $.ajax({
         type : 'GET',
-        url : '_player_engine.php?state=' + GUI.MpdState['state'],
+        url : url,
         async : true,
         cache : false,
         success : function(data) {
-			GUI.MpdState = data;
+            GUI.MpdState = data;
             renderUI();
-			$('#loader').hide();
-            backendRequest();
+            $('#loader').hide();
+            backendRequest(true);
         },
         error : function() {
             setTimeout(function() {
@@ -90,7 +91,7 @@ function backendRequest() {
                 $('#loader').show();
                 $('#countdown-display').countdown('pause');
                 window.clearInterval(GUI.currentKnob);
-                backendRequest();
+                backendRequest(false);
             }, 2000);
         }
     });

--- a/js/volumio.playback.js
+++ b/js/volumio.playback.js
@@ -32,7 +32,7 @@ jQuery(document).ready(function($){ 'use strict';
     // INITIALIZATION
     // ----------------------------------------------------------------------------------------------------
     // first connection with MPD and SPOP daemons
-    backendRequest();
+    backendRequest(true);
 	backendRequestSpop();
 
     // first GUI update

--- a/js/volumio.settings.js
+++ b/js/volumio.settings.js
@@ -22,14 +22,14 @@
  *  - v1, 1.1: Simone De Gregori (aka Orion)
  *  - v2: Michelangelo Guarise
  *  - v2: Joel Takvorian
- * 
+ *
  *  file:                    volumio.settings.js
  *  version:                 2
  */
 
 jQuery(document).ready(function($){ 'use strict';
 
-    backendRequest();
+    backendRequest(true);
 
     if (GUI.state != 'disconnected') {
         $('#loader').hide();


### PR DESCRIPTION
_player_engine.php blocks indefinately when the state sent by the client matches the current state.
But, in the case where the backendRequest hits an error, the app starts trying to reconnect in a
setTimeout loop while it shows a modal UI. So, we don't want _player_engine to block.

This adds an option to backendRequest to send state or not for the cases we want it to block or not.