### PR TITLE
added back button handler

### DIFF
--- a/js/volumio.playback.js
+++ b/js/volumio.playback.js
@@ -348,6 +348,21 @@ jQuery(document).ready(function($){ 'use strict';
         }
         getDB('filepath', path, GUI.browsemode, 1);
     });
+	
+	//handle back button press
+	window.addEventListener('popstate', function(event) {
+		--GUI.currentDBpos[10];
+        var path = GUI.currentpath;
+        var cutpos=path.lastIndexOf("/");
+        if (cutpos !=-1) {
+            var path = path.slice(0,cutpos);
+        }  else {
+            path = '';
+        }
+        getDB('filepath', path, GUI.browsemode, 1);
+		
+		history.pushState(null, null, window.location.pathname);
+	}, false);
 
     // click on database entry
     $('.database').on('click', '.db-browse', function() {


### PR DESCRIPTION
Use the back button to navigate the library, especially useful on Android where you have to reach all the way to the top of the screen to move up a folder.

tested working in Chrome Desktop and Android
